### PR TITLE
Add Albert to packages

### DIFF
--- a/packages
+++ b/packages
@@ -19,6 +19,7 @@ meld
 
 [ albert ]
 albert
+muparser
 
 [ kupfer ]
 kupfer

--- a/packages
+++ b/packages
@@ -5,7 +5,6 @@ icedtea-web
 grsync
 evince
 gnome-disk-utility
-kupfer
 deluge
 owncloud-client
 system-config-printer
@@ -17,6 +16,12 @@ ebook-tools
 gnome-font-viewer
 seahorse
 meld
+
+[ albert ]
+albert
+
+[ kupfer ]
+kupfer
 
 [ term apps ]
 bash-completion


### PR DESCRIPTION
Add Albert to packages.
Create own sections for Albert and Kupfer.
Add muparser as an Albert dependency in order to the Calculator to work.